### PR TITLE
fix(ci): configure deploy key authentication for semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,17 @@ jobs:
       pull-requests: write  # For creating PRs
     
     steps:
+      - name: Setup SSH key for semantic release
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SEMANTIC_RELEASE_SSH_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Full history for semantic release
-          token: ${{ secrets.GITHUB_TOKEN }}
-      
+          ssh-key: ${{ secrets.SEMANTIC_RELEASE_SSH_KEY }}
+
       - name: Python Semantic Release
         id: semantic
         uses: python-semantic-release/python-semantic-release@v9.21.1


### PR DESCRIPTION
## Summary
- Configure SSH deploy key authentication for semantic release workflow
- Enable semantic release to bypass repository protection rules
- Replace GitHub token with SSH key for git operations

## Changes
- Added SSH agent setup step to semantic release workflow  
- Configure checkout to use SSH key instead of GitHub token
- Private key stored as SEMANTIC_RELEASE_SSH_KEY secret
- Deploy key added to repository rules bypass list

## Test Plan
- [x] Deploy key configured with write access
- [x] Private key added to repository secrets  
- [x] Deploy key added to repository rules bypass
- [x] Workflow updated to use SSH authentication
- [ ] Verify semantic release can create version tags after merge

🤖 Generated with [Claude Code](https://claude.ai/code)