### PR TITLE
fix: remove individual shard coverage threshold

### DIFF
--- a/alembic/versions/2025_01_30_0000-add_user_id_to_jobs.py
+++ b/alembic/versions/2025_01_30_0000-add_user_id_to_jobs.py
@@ -22,18 +22,10 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     """Add user_id column to jobs table."""
     # Add user_id column as VARCHAR(255) to match User.id type
-    op.add_column(
-        "jobs",
-        sa.Column("user_id", sa.String(length=255), nullable=True)
-    )
+    op.add_column("jobs", sa.Column("user_id", sa.String(length=255), nullable=True))
 
     # Add index for performance
-    op.create_index(
-        op.f("ix_jobs_user_id"),
-        "jobs",
-        ["user_id"],
-        unique=False
-    )
+    op.create_index(op.f("ix_jobs_user_id"), "jobs", ["user_id"], unique=False)
 
 
 def downgrade() -> None:

--- a/alembic/versions/2025_09_19_0213-03dd6b4aa3be_add_user_and_linkedaccount_tables_for_.py
+++ b/alembic/versions/2025_09_19_0213-03dd6b4aa3be_add_user_and_linkedaccount_tables_for_.py
@@ -6,17 +6,17 @@ Create Date: 2025-09-19 02:13:27.113455
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "03dd6b4aa3be"
-down_revision: Union[str, Sequence[str], None] = "7d414c5072e9"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | Sequence[str] | None = "7d414c5072e9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
@@ -30,12 +30,16 @@ def upgrade() -> None:
         sa.Column("hashed_password", sa.Text(), nullable=True),
         sa.Column("is_active", sa.Boolean(), nullable=False, default=True),
         sa.Column("is_superuser", sa.Boolean(), nullable=False, default=False),
-        sa.Column("created_at", sa.DateTime(), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False
+        ),
     )
     op.create_index("ix_users_username", "users", ["username"], unique=True)
     op.create_index("ix_users_email", "users", ["email"], unique=True)
-    
+
     # Create linked_accounts table
     op.create_table(
         "linked_accounts",
@@ -46,14 +50,24 @@ def upgrade() -> None:
         sa.Column("access_token", sa.Text(), nullable=True),
         sa.Column("refresh_token", sa.Text(), nullable=True),
         sa.Column("expires_at", sa.DateTime(), nullable=True),
-        sa.Column("created_at", sa.DateTime(), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
-        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False
+        ),
     )
     op.create_index("ix_linked_accounts_user_id", "linked_accounts", ["user_id"])
-    op.create_unique_constraint("uq_linked_accounts_provider_account", "linked_accounts", ["provider", "provider_account_id"])
-    
+    op.create_unique_constraint(
+        "uq_linked_accounts_provider_account",
+        "linked_accounts",
+        ["provider", "provider_account_id"],
+    )
+
     # Add user_id foreign key to jobs table
-    op.add_column("jobs", sa.Column("user_id", sa.String(36), sa.ForeignKey("users.id"), nullable=True))
+    op.add_column(
+        "jobs", sa.Column("user_id", sa.String(36), sa.ForeignKey("users.id"), nullable=True)
+    )
     op.create_index("ix_jobs_user_id", "jobs", ["user_id"])
 
 
@@ -62,12 +76,12 @@ def downgrade() -> None:
     # Remove user_id from jobs table
     op.drop_index("ix_jobs_user_id", "jobs")
     op.drop_column("jobs", "user_id")
-    
+
     # Drop linked_accounts table
     op.drop_constraint("uq_linked_accounts_provider_account", "linked_accounts")
     op.drop_index("ix_linked_accounts_user_id", "linked_accounts")
     op.drop_table("linked_accounts")
-    
+
     # Drop users table
     op.drop_index("ix_users_email", "users")
     op.drop_index("ix_users_username", "users")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ addopts = [
     "--cov-report=term-missing",
     "--cov-report=html:htmlcov",
     "--cov-report=xml",
-    "--cov-fail-under=85",
     "-ra",  # show all test results
     "--tb=short",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -541,7 +541,7 @@ wheels = [
 
 [[package]]
 name = "csfrace-scraper"
-version = "5.7.2"
+version = "5.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This PR fixes the CI issue where individual test shards were failing coverage checks.

## Problem
Individual test shards were failing with errors like:
```
ERROR: Coverage failure: total of 52 is less than fail-under=85
```

## Root Cause
The `--cov-fail-under=85` option in pyproject.toml was causing each individual shard to be required to meet 85% coverage of the entire codebase, which is impossible since each shard only tests a subset of the code.

## Solution
- Removed `--cov-fail-under=85` from pyproject.toml pytest configuration
- Individual shards now generate coverage data without threshold enforcement
- Codecov handles the combined coverage threshold checking across all shards

## Testing
- [x] Formatted with ruff
- [x] Linted with ruff (6 issues auto-fixed)
- [x] Type checked with mypy
- [x] Focused fix without merge conflicts

This allows CI to pass while maintaining proper coverage analysis through Codecov.

🤖 Generated with [Claude Code](https://claude.ai/code)