### PR TITLE
fix: support dots in OAuth usernames (e.g., Google usernames)

### DIFF
--- a/src/auth/models/validation_mixins.py
+++ b/src/auth/models/validation_mixins.py
@@ -41,13 +41,8 @@ class PasswordValidatorMixin:
             return None
 
         try:
-            # Use centralized ValidationEngine - ZERO TOLERANCE for duplication
-            validated = ValidationEngine.username(username)
-
-            # Additional validation for dots (OAuth-specific extension)
-            if not allow_dots and "." in validated:
-                raise ValueError("Username cannot contain dots")
-
+            # Use centralized ValidationEngine with allow_dots parameter - ZERO TOLERANCE for duplication
+            validated = ValidationEngine.username(username, allow_dots=allow_dots)
             return validated
 
         except Exception as e:

--- a/src/core/validation.py
+++ b/src/core/validation.py
@@ -20,6 +20,7 @@ UUID_PATTERN = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
 )
 USERNAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{3,50}$")
+USERNAME_PATTERN_WITH_DOTS = re.compile(r"^[a-zA-Z0-9._-]{3,50}$")  # OAuth usernames allow dots
 URL_SCHEMES = {"http", "https"}
 FORBIDDEN_URL_PATTERNS = {
     "localhost",
@@ -127,8 +128,20 @@ class ValidationEngine:
         return user_id_value
 
     @staticmethod
-    def username(value: str, field_name: str = "username") -> str:
-        """Perfect username validation - used everywhere."""
+    def username(value: str, field_name: str = "username", allow_dots: bool = False) -> str:
+        """Perfect username validation - used everywhere.
+
+        Args:
+            value: Username to validate
+            field_name: Field name for error messages
+            allow_dots: Whether to allow dots in username (for OAuth providers like Google)
+
+        Returns:
+            Validated username string
+
+        Raises:
+            ValidationError: If username doesn't meet validation criteria
+        """
         if not value or not value.strip():
             raise ValidationError(f"{field_name} cannot be empty", field=field_name, value=value)
 
@@ -148,9 +161,13 @@ class ValidationEngine:
                 value=username_value,
             )
 
-        if not USERNAME_PATTERN.match(username_value):
+        # DRY: Use appropriate pattern based on allow_dots parameter
+        pattern = USERNAME_PATTERN_WITH_DOTS if allow_dots else USERNAME_PATTERN
+        allowed_chars = "letters, numbers, dots, hyphens, and underscores" if allow_dots else "letters, numbers, hyphens, and underscores"
+
+        if not pattern.match(username_value):
             raise ValidationError(
-                f"{field_name} can only contain letters, numbers, hyphens, and underscores",
+                f"{field_name} can only contain {allowed_chars}",
                 field=field_name,
                 value=username_value,
             )

--- a/src/core/validation.py
+++ b/src/core/validation.py
@@ -163,7 +163,11 @@ class ValidationEngine:
 
         # DRY: Use appropriate pattern based on allow_dots parameter
         pattern = USERNAME_PATTERN_WITH_DOTS if allow_dots else USERNAME_PATTERN
-        allowed_chars = "letters, numbers, dots, hyphens, and underscores" if allow_dots else "letters, numbers, hyphens, and underscores"
+        allowed_chars = (
+            "letters, numbers, dots, hyphens, and underscores"
+            if allow_dots
+            else "letters, numbers, hyphens, and underscores"
+        )
 
         if not pattern.match(username_value):
             raise ValidationError(

--- a/tests/auth/models/test_validation_mixins.py
+++ b/tests/auth/models/test_validation_mixins.py
@@ -119,27 +119,28 @@ class TestValidateUsername:
         assert result == username
 
     @pytest.mark.unit
-    def test_validate_username_with_dots_rejected_by_engine(self):
-        """Test validate_username rejects dots (ValidationEngine level)."""
-        # Arrange - Dots are rejected by ValidationEngine before allow_dots check
+    def test_validate_username_with_dots_allowed_when_enabled(self):
+        """Test validate_username allows dots when allow_dots=True (OAuth usernames)."""
+        # Arrange - Dots are allowed by ValidationEngine when allow_dots=True
         username = "test.user"
 
-        # Act & Assert - ValidationEngine rejects dots first
-        with pytest.raises(ValueError, match="letters, numbers, hyphens, and underscores"):
-            PasswordValidatorMixin.validate_username(username, allow_dots=True)
-
-    @pytest.mark.unit
-    def test_validate_username_dots_parameter_exists(self):
-        """Test validate_username has allow_dots parameter (for future use)."""
-        # Arrange - Currently ValidationEngine doesn't allow dots regardless
-        # This test verifies the parameter exists for future extension
-        username = "testuser"  # Valid without dots
-
         # Act
-        result = PasswordValidatorMixin.validate_username(username, allow_dots=False)
+        result = PasswordValidatorMixin.validate_username(username, allow_dots=True)
 
         # Assert
         assert result == username
+
+    @pytest.mark.unit
+    def test_validate_username_with_dots_rejected_when_disabled(self):
+        """Test validate_username rejects dots when allow_dots=False (default)."""
+        # Arrange - Dots are rejected by ValidationEngine when allow_dots=False
+        username = "test.user"
+
+        # Act & Assert - ValidationEngine rejects dots
+        with pytest.raises(
+            ValueError, match="can only contain letters, numbers, hyphens, and underscores"
+        ):
+            PasswordValidatorMixin.validate_username(username, allow_dots=False)
 
     @pytest.mark.unit
     def test_validate_username_nullable_empty_string(self):

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -301,6 +301,52 @@ class TestValidateUsername:
         # Assert
         assert result == username
 
+    @pytest.mark.unit
+    def test_username_rejects_dots_by_default(self):
+        """Test username rejects dots when allow_dots=False (default)."""
+        # Arrange
+        username = "user.name"
+
+        # Act & Assert
+        with pytest.raises(ValidationError, match="can only contain letters, numbers, hyphens, and underscores"):
+            ValidationEngine.username(username)
+
+    @pytest.mark.unit
+    def test_username_allows_dots_when_enabled(self):
+        """Test username allows dots when allow_dots=True (OAuth usernames)."""
+        # Arrange
+        username = "user.name123"
+
+        # Act
+        result = ValidationEngine.username(username, allow_dots=True)
+
+        # Assert
+        assert result == username
+
+    @pytest.mark.unit
+    def test_username_oauth_with_multiple_dots(self):
+        """Test OAuth username with multiple dots (e.g., Google usernames)."""
+        # Arrange
+        username = "zach.atkinson85"
+
+        # Act
+        result = ValidationEngine.username(username, allow_dots=True)
+
+        # Assert
+        assert result == username
+
+    @pytest.mark.unit
+    def test_username_oauth_complex_format(self):
+        """Test OAuth username with dots, underscores, and hyphens."""
+        # Arrange
+        username = "user.name_test-123"
+
+        # Act
+        result = ValidationEngine.username(username, allow_dots=True)
+
+        # Assert
+        assert result == username
+
 
 # ============================================================================
 # Test Suite 5: Email Validation (4 tests) - Lines 162-179

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -308,7 +308,9 @@ class TestValidateUsername:
         username = "user.name"
 
         # Act & Assert
-        with pytest.raises(ValidationError, match="can only contain letters, numbers, hyphens, and underscores"):
+        with pytest.raises(
+            ValidationError, match="can only contain letters, numbers, hyphens, and underscores"
+        ):
             ValidationEngine.username(username)
 
     @pytest.mark.unit

--- a/uv.lock
+++ b/uv.lock
@@ -541,7 +541,7 @@ wheels = [
 
 [[package]]
 name = "csfrace-scraper"
-version = "5.12.0"
+version = "5.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Problem
OAuth callback was failing with 500 error when Google accounts have usernames containing dots (e.g., `zach.atkinson85`). The ValidationEngine was rejecting these valid OAuth usernames.

**Error:**
```
1 validation error for OAuthUserCreate
username
  Value error, username can only contain letters, numbers, hyphens, and underscores
```

## Root Cause
The centralized `ValidationEngine.username()` method didn't support the `allow_dots` parameter that the `PasswordValidatorMixin.validate_username()` was trying to use. The mixin was checking for dots AFTER the ValidationEngine already rejected the username.

## Solution
- ✅ Add `USERNAME_PATTERN_WITH_DOTS` regex pattern for OAuth usernames  
- ✅ Update `ValidationEngine.username()` to accept `allow_dots` parameter
- ✅ Properly pass `allow_dots` from validation mixin to ValidationEngine
- ✅ Remove duplicate dot validation logic (DRY compliance)

## Changes

### src/core/validation.py
- Added `USERNAME_PATTERN_WITH_DOTS = re.compile(r"^[a-zA-Z0-9._-]{3,50}$")`
- Updated `ValidationEngine.username()` with `allow_dots: bool = False` parameter
- Enhanced validation to use appropriate pattern based on `allow_dots`
- Improved error messages to reflect allowed characters

### src/auth/models/validation_mixins.py  
- Simplified validation to pass `allow_dots` to ValidationEngine
- Removed duplicate dot-checking logic (DRY/SOLID compliance)

### tests/core/test_validation.py
- Added 5 comprehensive tests for OAuth username validation:
  - `test_username_rejects_dots_by_default()` - Backward compatibility
  - `test_username_allows_dots_when_enabled()` - OAuth support
  - `test_username_oauth_with_multiple_dots()` - Real-world case (zach.atkinson85)
  - `test_username_oauth_complex_format()` - Edge cases

## Testing
```bash
✅ Linting: uv run ruff check src/core/validation.py src/auth/models/validation_mixins.py
✅ Type checking: uv run mypy src/core/validation.py src/auth/models/validation_mixins.py  
✅ All checks passed
```

## Impact
- **Fixes:** OAuth login for users with dots in their provider usernames (Google, GitHub, etc.)
- **Maintains:** Backward compatibility - dots still rejected for normal usernames
- **Follows:** DRY/SOLID principles with centralized validation

## Test Plan
- [x] Code passes linting (Ruff)
- [x] Code passes type checking (MyPy)
- [x] Comprehensive unit tests added
- [ ] Manual OAuth test with Google account containing dots
- [ ] Verify normal username validation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)