### PR TITLE
fix: remove build-target parameter for flexible Dockerfile support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,6 @@ jobs:
       version: ${{ needs.semantic-release.outputs.version }}
       dockerfile-path: ./Dockerfile
       build-context: .
-      build-target: production
 
   # Job 3: Notify orchestrator (DRY: Reusable workflow)
   notify-orchestrator:


### PR DESCRIPTION
## Summary
Removes the `build-target: production` parameter from the Docker publish workflow to support both single-stage and multi-stage Dockerfiles without requiring specific named stages.

## Problem
The current workflow explicitly passes `build-target: production` to the reusable Docker publish workflow. This causes builds to fail when:
- Dockerfiles don't have a stage explicitly named "production"
- Single-stage Dockerfiles are used (no named stages at all)
- Multi-stage Dockerfiles use different stage naming conventions

## Solution
**Removed**: `build-target: production` parameter from `release.yml`

When no `--target` is specified, Docker's default behavior is:
- **Single-stage Dockerfile**: Builds the only stage
- **Multi-stage Dockerfile**: Builds the final stage automatically

## Benefits
✅ **More flexible**: Works with any Dockerfile structure
✅ **Less coupling**: No need to coordinate stage names between Dockerfile and workflow
✅ **Docker best practice**: Leverages Docker's default behavior
✅ **Backward compatible**: Backend Dockerfile already uses multi-stage (builder → production as final stage)

## Changes
**File**: `.github/workflows/release.yml:79`
- **Removed**: `build-target: production`

## Current Backend Dockerfile Structure
```dockerfile
# Stage 1: builder (build dependencies)
FROM python:3.13-slim-bookworm AS builder
...

# Stage 2: production (final runtime stage)
FROM python:3.13-slim-bookworm AS production
...
```

Since "production" is the final stage, Docker will build it automatically when no `--target` is specified.

## Testing
✅ Backend Dockerfile uses multi-stage build (builder → production)
✅ Production stage is the final stage
✅ Docker will build production stage by default
✅ No functional change to resulting image
✅ Workflow will now support future Dockerfile structure changes

## Impact
- **No breaking changes**: Maintains current build behavior
- **Improved flexibility**: Easier to refactor Dockerfiles in the future
- **Consistent with frontend**: Both repos now use the same pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>